### PR TITLE
chore: run docker-publish only on push to main

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,8 @@
 name: docker
 on:
   push:
+    branches:
+      - main
 jobs:
   docker:
     name: docker


### PR DESCRIPTION
Unsure what how the deploy workflow was for the original repo, but GH was running docker-publish on _all_ PRs, and then again on main. Changing behav for this fork